### PR TITLE
Add exports linking speed up suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Whether you use this project or not, there are a number of things that can speed
 
 - The linker flag `-Wl,-no_uuid`, which disables UUID creation
 - Turning off dead stripping (referred to as "Dead Code Stripping" in Xcode build settings)
+- For executables and xctest bundles, disable dyld exports trie creation with `-Wl,-exported_symbols_list,/dev/null` (cannot be when xctests that call into their test host app)
 - If you're not using `zld`, using `-Wl,-force_load` for libraries can sometimes speed things up
 - Linking with dynamic libraries instead of static ones
 


### PR DESCRIPTION
We've recently started using `-exported_symbols_list /dev/null` to prevent the linker from creating an exports trie, which for most cases will never be used. It reduced link times by around 8%, but others have reported 15% and more.

This is applicable to both local development builds, and also release builds. The only time an application needs its dyld linked exports is when it is used as a test host, and even then only when the test bundle calls into the test host.

For dylibs, this would break linking.