### PR TITLE
Ignore -platform_version flag

### DIFF
--- a/ld/src/ld/Options.cpp
+++ b/ld/src/ld/Options.cpp
@@ -3857,6 +3857,10 @@ void Options::parse(int argc, const char* argv[])
 			else if (strcmp(arg, "-debug_variant") == 0) {
 			    fDebugVariant = true;
             }
+			else if (strcmp(arg, "-platform_version") == 0) {
+				i += 3;
+				// no-op until we understand exactly what this flag does
+			}
 			else if (strcmp(arg, "-no_new_main") == 0) {
 				// HACK until 39514191 is fixed
 			}


### PR DESCRIPTION
From https://github.com/michaeleisel/zld/issues/8

Skips `-platform_version platform min_version sdk_version` and makes zld work on Xcode 11.4