### PR TITLE
Force load archives with Swift symbols

### DIFF
--- a/ld/src/ld/Options.cpp
+++ b/ld/src/ld/Options.cpp
@@ -194,7 +194,7 @@ Options::Options(int argc, const char* argv[])
 	  fKeepDwarfUnwindForcedOn(false), fKeepDwarfUnwindForcedOff(false),
 	  fVerboseOptimizationHints(false), fIgnoreOptimizationHints(false),
 	  fGenerateDtraceDOF(true), fAllowBranchIslands(true), fTraceSymbolLayout(false), 
-	  fMarkAppExtensionSafe(false), fCheckAppExtensionSafe(false), fForceLoadSwiftLibs(false),
+	  fMarkAppExtensionSafe(false), fCheckAppExtensionSafe(false), fForceLoadSwiftLibs(true),
 	  fSharedRegionEncodingV2(false), fUseDataConstSegment(false),
 	  fUseDataConstSegmentForceOn(false), fUseDataConstSegmentForceOff(false), fUseTextExecSegment(false),
 	  fBundleBitcode(false), fHideSymbols(false), fVerifyBitcode(false),

--- a/ld/src/ld/parsers/archive_file.cpp
+++ b/ld/src/ld/parsers/archive_file.cpp
@@ -101,6 +101,7 @@ private:
 	static bool										validLTOFile(const uint8_t* fileContent, uint64_t fileLength, 
 																	const mach_o::relocatable::ParserOptions& opts);
 	static cpu_type_t								architecture();
+	bool										    hasSwift() const;
 
 	class Entry : ar_hdr
 	{
@@ -467,7 +468,7 @@ template <typename A>
 bool File<A>::forEachAtom(ld::File::AtomHandler& handler) const
 {
 	bool didSome = false;
-	if ( _forceLoadAll || _forceLoadThis ) {
+	if ( _forceLoadAll || _forceLoadThis || hasSwift() ) {
 		// call handler on all .o files in this archive
 		const Entry* const start = (Entry*)&_archiveFileContent[8];
 		const Entry* const end = (Entry*)&_archiveFileContent[_archiveFilelength];
@@ -534,6 +535,17 @@ bool File<A>::forEachAtom(ld::File::AtomHandler& handler) const
 		}
 	}
 	return didSome;
+}
+
+template <typename A>
+bool File<A>::hasSwift() const {
+	for (const auto& entry : _hashTable) {
+		if ( (strncmp(entry.first, "$s", 2) == 0) || (strncmp(entry.first, "_$s", 3) == 0) ) {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 template <typename A>


### PR DESCRIPTION
This is a fix for radar 47598583:

"Linking against a static Swift library might create a binary with missing type metadata because the object files that define the metadata inside the static archive are mistakenly considered unused. (47598583)"

The issue was fixed in ld64 in Xcode 11:

"Static libraries are now always force-loaded in their entirety during linking, fixing most “unable to demangle” runtime errors. (47598583)"

The PR applies -force_load to all archives containing any Swift symbols. Fixes #16, #20.