### PR TITLE
handle -platform_version

### DIFF
--- a/ld/src/ld/Options.cpp
+++ b/ld/src/ld/Options.cpp
@@ -3858,8 +3858,16 @@ void Options::parse(int argc, const char* argv[])
 			    fDebugVariant = true;
             }
 			else if (strcmp(arg, "-platform_version") == 0) {
-				i += 3;
-				// no-op until we understand exactly what this flag does
+				// https://reviews.llvm.org/D71579
+				const char* platformStr = checkForNullVersionArgument(arg, argv[++i]);
+				const char* minVersion = checkForNullVersionArgument(arg, argv[++i]);
+				const char* sdkVersion = checkForNullVersionArgument(arg, argv[++i]);
+				fSDKVersion = parseVersionNumber32(sdkVersion);
+				ld::Platform platform = ld::platformFromString(platformStr);
+				if (platform == ld::kPlatform_unknown) {
+					throwf("unknown platform: %s", platformStr);
+				}
+				setVersionMin(platform, minVersion);
 			}
 			else if (strcmp(arg, "-no_new_main") == 0) {
 				// HACK until 39514191 is fixed

--- a/ld/src/ld/ld.cpp
+++ b/ld/src/ld/ld.cpp
@@ -103,6 +103,28 @@ const ld::Platform ld::basePlatform(const ld::Platform& platform)  {
 	}
 }
 
+const ld::Platform ld::platformFromString(const char* platformString) {
+	static const char* platforms[] = {
+		"",						// unknown
+		"macos",
+		"ios",
+		"tvos",
+		"watchos",
+		"",						// bridgeOS not supported
+		"",						// Catalyst not supported
+		"ios-simulator",
+		"tvos-simulator",
+		"watchos-simulator"
+	};
+
+	for (int i = ld::kPlatform_macOS; i <= ld::kPlatform_watchOSSimulator; i++) {
+		if ( strcmp(platformString, platforms[i]) == 0 ) {
+			return ld::Platform(i);
+		}
+	}
+	return ld::kPlatform_unknown;
+}
+
 const ld::VersionSet ld::File::_platforms;
 
 struct PerformanceStatistics {

--- a/ld/src/ld/ld.hpp
+++ b/ld/src/ld/ld.hpp
@@ -63,6 +63,8 @@ enum Platform {
 
 const ld::Platform basePlatform(const ld::Platform& platform);
 
+const ld::Platform platformFromString(const char* platformString);
+
 typedef LDOrderedSet<Platform> PlatformSet;
 
 //


### PR DESCRIPTION
Handle the new `-platform_version` flag, this is a triple of platform, deployment target and SDK version.