### PR TITLE
Add test support to the CI flow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,3 +11,5 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_11.2.app/Contents/Developer
       - name: Build
         run: make
+      - name: Test
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,9 @@
 build: fetch
 	xcodebuild -project ld/zld.xcodeproj -scheme zld -derivedDataPath build -configuration Release build
 
+test: fetch
+	xcodebuild -project ld/zld.xcodeproj -scheme unit-tests -derivedDataPath build -configuration Debug build
+
 abseil-cpp-20200225:
 	curl -# -L https://github.com/abseil/abseil-cpp/archive/20200225.tar.gz | tar xz
 	mkdir $@/build


### PR DESCRIPTION
Now that the unit-test target is working in the project, add it to the Makefile and to the Github action config.