### PR TITLE
Update test case whitelist

### DIFF
--- a/ld/unit-tests/arm64_whitelist
+++ b/ld/unit-tests/arm64_whitelist
@@ -63,6 +63,7 @@ no-object-symbols
 non-lazy-r
 non-lazy-sections-r
 objc-category-class-property-mismatch
+objc-category-optimize
 operator-new
 prebound-split-seg
 re-export-cases

--- a/ld/unit-tests/x86_64_whitelist
+++ b/ld/unit-tests/x86_64_whitelist
@@ -16,3 +16,4 @@ linker-optimization-hints
 lto-weak-native-override
 llvm-integration
 objc-category-class-property-mismatch
+objc-category-optimize


### PR DESCRIPTION
`objc-category-optimize` is failing for me with Xcode 11.4.1. unit tests were all passing before, so my only guess is that the newer xcode's toolchain somehow caused this