### PR TITLE
Revert parallel order sorting

### DIFF
--- a/ld/src/ld/passes/order.cpp
+++ b/ld/src/ld/passes/order.cpp
@@ -644,14 +644,7 @@ void Layout::doPass()
 				break;
 			default:
 				if ( log ) fprintf(stderr, "sorting section %s\n", sect->sectionName());
-				// riskier
-				if (Tweaks::reproEnabled()) {
     				std::sort(sect->atoms.begin(), sect->atoms.end(), _comparer);
-				} else {
-    				std::sort(std::execution::par, sect->atoms.begin(), sect->atoms.end(), _comparer);
-				}
-				// note that is_sorted fails here, probably because of some shenanigans around aliases in _comparer.
-				// but it doesn't seem to be a regression
 				break;
 		}
 	}


### PR DESCRIPTION
This was causing a strange bug where a stack overflow would occur. This particular place has always been a bit janky, but seemed sound until this issue. A larger investigation would be good, but for now this seems like a good change to get into master. Thanks to @rmaz for finding this issue