### PR TITLE
Upgrade TAPI to work with Catalyst

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /dyld-635.2/
 /llvm-7.0.1.src/
 /pstl/
-/tapi/
+/tapitapi-1100.0.11/
 /tbb/
 
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /dyld-635.2/
 /llvm-7.0.1.src/
 /pstl/
-/tapitapi-1100.0.11/
+/tapi-1100.0.11/
 /tbb/
 
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,7 @@
 /dyld-635.2/
 /llvm-7.0.1.src/
 /pstl/
-/tapi-b920569/
-/tapi-master/
+/tapi/
 /tbb/
 
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,13 @@ cfe-7.0.1.src:
 	curl -# -L http://releases.llvm.org/7.0.1/cfe-7.0.1.src.tar.xz | tar xJ
 
 clean:
-	rm -rf abseil-cpp-20200225 build cfe-7.0.1.src dyld-635.2 llvm-7.0.1.src pstl tapi-b920569 tbb
+	rm -rf abseil-cpp-20200225 build cfe-7.0.1.src dyld-635.2 llvm-7.0.1.src pstl tapi tbb
 
 dyld-635.2:
 	curl -# -L https://opensource.apple.com/tarballs/dyld/dyld-635.2.tar.gz | tar xz
 	patch -p1 -d dyld-635.2 < patches/dyld.patch
 
-fetch: abseil-cpp-20200225 cfe-7.0.1.src dyld-635.2 llvm-7.0.1.src tapi-b920569 tbb
+fetch: abseil-cpp-20200225 cfe-7.0.1.src dyld-635.2 llvm-7.0.1.src tapi tbb
 
 llvm-7.0.1.src:
 	curl -# -L http://releases.llvm.org/7.0.1/llvm-7.0.1.src.tar.xz | tar xJ
@@ -32,9 +32,9 @@ package:
 	tar -C build/Build/Products/Release -cvJf build/Build/Products/Release/zld.$(HASH).tar.xz zld
 	tar -C build/Build/Products/Release -cvJf build/Build/Products/Release/zld.dSYM.$(HASH).tar.xz zld.dSYM
 
-tapi-b920569:
+tapi:
 	mkdir -p $@
-	curl -# -L https://github.com/ributzka/tapi/tarball/b920569 | tar xz -C $@ --strip-components=1
+	curl -# -L https://opensource.apple.com/tarballs/tapi/tapi-1100.0.11.tar.gz | tar xz -C $@ --strip-components=1
 	patch -p1 -d $@ < patches/tapi.patch
 
 tbb:

--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,13 @@ cfe-7.0.1.src:
 	curl -# -L http://releases.llvm.org/7.0.1/cfe-7.0.1.src.tar.xz | tar xJ
 
 clean:
-	rm -rf abseil-cpp-20200225 build cfe-7.0.1.src dyld-635.2 llvm-7.0.1.src pstl tapi tbb
+	rm -rf abseil-cpp-20200225 build cfe-7.0.1.src dyld-635.2 llvm-7.0.1.src pstl tapi-1100.0.11 tbb
 
 dyld-635.2:
 	curl -# -L https://opensource.apple.com/tarballs/dyld/dyld-635.2.tar.gz | tar xz
 	patch -p1 -d dyld-635.2 < patches/dyld.patch
 
-fetch: abseil-cpp-20200225 cfe-7.0.1.src dyld-635.2 llvm-7.0.1.src tapi tbb
+fetch: abseil-cpp-20200225 cfe-7.0.1.src dyld-635.2 llvm-7.0.1.src tapi-1100.0.11 tbb
 
 llvm-7.0.1.src:
 	curl -# -L http://releases.llvm.org/7.0.1/llvm-7.0.1.src.tar.xz | tar xJ
@@ -32,7 +32,7 @@ package:
 	tar -C build/Build/Products/Release -cvJf build/Build/Products/Release/zld.$(HASH).tar.xz zld
 	tar -C build/Build/Products/Release -cvJf build/Build/Products/Release/zld.dSYM.$(HASH).tar.xz zld.dSYM
 
-tapi:
+tapi-1100.0.11:
 	mkdir -p $@
 	curl -# -L https://opensource.apple.com/tarballs/tapi/tapi-1100.0.11.tar.gz | tar xz -C $@ --strip-components=1
 	patch -p1 -d $@ < patches/tapi.patch

--- a/ld/src/ld/ld.cpp
+++ b/ld/src/ld/ld.cpp
@@ -1372,29 +1372,12 @@ int main(int argc, const char* argv[])
 			forceZld = true;
 		}
 
-		if (!forceZld) {
-			if (isArm64_32) {
-				useFallbackLd(fallbackPath, argc, argv, "WatchOS");
-			}
-
-			// python 2 and python 3 both work with this invocation
-			char *cmd = NULL;
-			asprintf(&cmd, "%s -version_details | python -c \"import sys, json; print(json.load(sys.stdin)['version'])\"", fallbackPath);
-			FILE *file = popen(cmd, "r");
-			int majorVersion = 0;
-			fscanf(file, "%d", &majorVersion);
-			if (majorVersion > 556 && !forceZld) {
-				useFallbackLd(fallbackPath, argc, argv, "Xcode 12");
-			}
+		if (!forceZld && isArm64_32) {
+			useFallbackLd(fallbackPath, argc, argv, "WatchOS");
 		}
 
 		// create object to track command line arguments
 		Options options(argc, argv);
-
-		bool supportsCatalyst = options.platforms().contains(ld::Platform::iOSMac);
-		if (supportsCatalyst && !forceZld) {
-			useFallbackLd(fallbackPath, argc, argv, "Catalyst");
-		}
 
 		InternalState state(options);
 		

--- a/ld/zld.xcodeproj/project.pbxproj
+++ b/ld/zld.xcodeproj/project.pbxproj
@@ -1273,7 +1273,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(DT_TOOLCHAIN_DIR)/usr/local/include",
 					"$(TOOLCHAIN_DIR)/usr/local/include",
-					"$(SRCROOT)/../tapi-b920569/include",
+					"$(SRCROOT)/../tapi/include",
 					"$(SRCROOT)/../dyld-635.2/include",
 					"$(SRCROOT)/../llvm-7.0.1.src/include",
 					"$(SRCROOT)/../cfe-7.0.1.src/include",
@@ -1367,7 +1367,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(DT_TOOLCHAIN_DIR)/usr/local/include",
 					"$(TOOLCHAIN_DIR)/usr/local/include",
-					"$(SRCROOT)/../tapi-b920569/include",
+					"$(SRCROOT)/../tapi/include",
 					"$(SRCROOT)/../dyld-635.2/include",
 					"$(SRCROOT)/../llvm-7.0.1.src/include",
 					"$(SRCROOT)/../cfe-7.0.1.src/include",
@@ -1721,7 +1721,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(DT_TOOLCHAIN_DIR)/usr/local/include",
 					"$(TOOLCHAIN_DIR)/usr/local/include",
-					"$(SRCROOT)/../tapi-b920569/include",
+					"$(SRCROOT)/../tapi/include",
 					"$(SRCROOT)/../dyld-635.2/include",
 					"$(SRCROOT)/../llvm-7.0.1.src/include",
 					"$(SRCROOT)/../cfe-7.0.1.src/include",

--- a/ld/zld.xcodeproj/project.pbxproj
+++ b/ld/zld.xcodeproj/project.pbxproj
@@ -1273,7 +1273,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(DT_TOOLCHAIN_DIR)/usr/local/include",
 					"$(TOOLCHAIN_DIR)/usr/local/include",
-					"$(SRCROOT)/../tapi/include",
+					"$(SRCROOT)/../tapi-1100.0.11/include",
 					"$(SRCROOT)/../dyld-635.2/include",
 					"$(SRCROOT)/../llvm-7.0.1.src/include",
 					"$(SRCROOT)/../cfe-7.0.1.src/include",
@@ -1367,7 +1367,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(DT_TOOLCHAIN_DIR)/usr/local/include",
 					"$(TOOLCHAIN_DIR)/usr/local/include",
-					"$(SRCROOT)/../tapi/include",
+					"$(SRCROOT)/../tapi-1100.0.11/include",
 					"$(SRCROOT)/../dyld-635.2/include",
 					"$(SRCROOT)/../llvm-7.0.1.src/include",
 					"$(SRCROOT)/../cfe-7.0.1.src/include",
@@ -1510,7 +1510,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(DT_TOOLCHAIN_DIR)/usr/local/include",
 					"$(TOOLCHAIN_DIR)/usr/local/include",
-					"$(SRCROOT)/../tapi-b920569/include",
+					"$(SRCROOT)/../tapi-1100.0.11/include",
 					"$(SRCROOT)/../dyld-635.2/include",
 					"$(SRCROOT)/../llvm-7.0.1.src/include",
 					"$(SRCROOT)/../cfe-7.0.1.src/include",
@@ -1563,7 +1563,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(DT_TOOLCHAIN_DIR)/usr/local/include",
 					"$(TOOLCHAIN_DIR)/usr/local/include",
-					"$(SRCROOT)/../tapi-b920569/include",
+					"$(SRCROOT)/../tapi-1100.0.11/include",
 					"$(SRCROOT)/../dyld-635.2/include",
 					"$(SRCROOT)/../llvm-7.0.1.src/include",
 					"$(SRCROOT)/../cfe-7.0.1.src/include",
@@ -1633,7 +1633,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(DT_TOOLCHAIN_DIR)/usr/local/include",
 					"$(TOOLCHAIN_DIR)/usr/local/include",
-					"$(SRCROOT)/../tapi-b920569/include",
+					"$(SRCROOT)/../tapi-1100.0.11/include",
 					"$(SRCROOT)/../dyld-635.2/include",
 					"$(SRCROOT)/../llvm-7.0.1.src/include",
 					"$(SRCROOT)/../cfe-7.0.1.src/include",
@@ -1721,7 +1721,7 @@
 				HEADER_SEARCH_PATHS = (
 					"$(DT_TOOLCHAIN_DIR)/usr/local/include",
 					"$(TOOLCHAIN_DIR)/usr/local/include",
-					"$(SRCROOT)/../tapi/include",
+					"$(SRCROOT)/../tapi-1100.0.11/include",
 					"$(SRCROOT)/../dyld-635.2/include",
 					"$(SRCROOT)/../llvm-7.0.1.src/include",
 					"$(SRCROOT)/../cfe-7.0.1.src/include",

--- a/patches/tapi.patch
+++ b/patches/tapi.patch
@@ -1,59 +1,8 @@
-diff -Naur tapi-master/include/tapi/APIVersion.h tapi-master.old/include/tapi/APIVersion.h
---- tapi-master/include/tapi/APIVersion.h	2017-09-07 16:09:54.000000000 -0700
-+++ tapi-master.old/include/tapi/APIVersion.h	2019-01-18 21:13:56.000000000 -0800
-@@ -25,7 +25,7 @@
- ///
- 
- #define TAPI_API_VERSION_MAJOR 1U
--#define TAPI_API_VERSION_MINOR 2U
-+#define TAPI_API_VERSION_MINOR 3U
- #define TAPI_API_VERSION_PATCH 0U
- 
- namespace tapi {
-diff -Naur tapi-master/include/tapi/LinkerInterfaceFile.h tapi-master.old/include/tapi/LinkerInterfaceFile.h
---- tapi-master/include/tapi/LinkerInterfaceFile.h	2017-09-07 16:09:54.000000000 -0700
-+++ tapi-master.old/include/tapi/LinkerInterfaceFile.h	2019-01-18 21:24:04.000000000 -0800
-@@ -260,6 +260,12 @@
-          cpu_type_t cpuType, cpu_subtype_t cpuSubType, ParsingFlags flags,
-          PackedVersion32 minOSVersion, std::string &errorMessage) noexcept;
- 
-+  static LinkerInterfaceFile *
-+  create(const std::string &path,
-+         cpu_type_t cpuType, cpu_subtype_t cpuSubType,
-+         ParsingFlags flags,
-+         PackedVersion32 minOSVersion, std::string &errorMessage) noexcept;
-+
-   ///
-   /// \brief Query the file type.
-   /// \return Returns the file type this TAPI file represents.
-@@ -360,6 +366,13 @@
-   ///
-   const std::string &getParentFrameworkName() const noexcept;
- 
-+
-+  LinkerInterfaceFile* getInlinedFramework(const std::string &path,
-+                                           cpu_type_t cpuType,
-+                                           cpu_subtype_t cpuSubType,
-+                                           ParsingFlags flags,
-+                                           PackedVersion32 minOSVersion,
-+                                           std::string &errorMessage) const noexcept;
-   ///
-   /// \brief Obtain the list of allowable clients.
-   /// \return Returns a list of allowable clients.
-@@ -395,6 +408,8 @@
-   ///
-   const std::vector<Symbol> &undefineds() const noexcept;
- 
-+  const std::vector<std::string> &inlinedFrameworkNames() const noexcept;
-+  
-   ///
-   /// \brief Destructor.
-   /// \since 1.0
 diff -Naur tapi-master/include/tapi/Version.inc tapi-master.old/include/tapi/Version.inc
 --- tapi-master/include/tapi/Version.inc	1969-12-31 16:00:00.000000000 -0800
 +++ tapi-master.old/include/tapi/Version.inc	2019-01-18 20:36:48.000000000 -0800
 @@ -0,0 +1,4 @@
-+#define TAPI_VERSION 1.3.0
++#define TAPI_VERSION 1.6.0
 +#define TAPI_VERSION_MAJOR 1U
-+#define TAPI_VERSION_MINOR 3U
++#define TAPI_VERSION_MINOR 6U
 +#define TAPI_VERSION_PATCH 0U


### PR DESCRIPTION
- Update tapi headers
- Remove fallback for Catalyst
- Remove fallback for Xcode 12 (seems like the newer tapi has fixed this as well)

After looking at issue again, I realized I was mistaken and that the newest released headers by Apple do support it. So, this just updates to the latest from opensource.apple.com (still really hoping they release new tapi headers soon, but this fixes the apparent issues afaict)