### PR TITLE
Whitelist failing demangle test

### DIFF
--- a/ld/unit-tests/x86_64_whitelist
+++ b/ld/unit-tests/x86_64_whitelist
@@ -17,3 +17,4 @@ lto-weak-native-override
 llvm-integration
 objc-category-class-property-mismatch
 objc-category-optimize
+demangle


### PR DESCRIPTION
This test has been broken since at least the last release. I imagine it broke due to me upgrading to Xcode 12 (as a reminder, ld has a lot of broken tests regardless of zld or stock ld, so I just whitelist ones that suddenly break due to something unrelated like the toolchain)