### PR TITLE
Prevent crashing immediately when an auto-linked library can't be found

### DIFF
--- a/ld/src/ld/InputFiles.cpp
+++ b/ld/src/ld/InputFiles.cpp
@@ -715,6 +715,7 @@ void InputFiles::addLinkerOptionLibraries(ld::Internal& state, ld::File::AtomHan
 		CStringSet newLibraries = std::move(state.unprocessedLinkerOptionLibraries);
 		std::vector<std::pair<Options::FileInfo, const char *>> infosToParse;
 		state.unprocessedLinkerOptionLibraries.clear();
+		// The try-catch statement here is a bit tricky w.r.t. the parallelization, see https://github.com/michaeleisel/zld/pull/63
 		for (const char* libName : newLibraries) {
 			if ( state.linkerOptionLibraries.count(libName) )
 				continue;
@@ -729,10 +730,7 @@ void InputFiles::addLinkerOptionLibraries(ld::Internal& state, ld::File::AtomHan
 				}
 			}
 			catch (const char* msg) {
-				if ( strstr(msg, "but linking") != nullptr )
-					warning("%s '%s'", msg, "<libname>");
-				// <rdar://problem/40829444> only warn about missing auto-linked library if some missing symbol error happens later
-				state.missingLinkerOptionLibraries.insert(libName);
+				handleLinkerOptionException(msg, state, libName);
 			}
 		}
 		typedef std::tuple<ld::File *, Options::FileInfo&, const char *> Triple;
@@ -774,14 +772,18 @@ void InputFiles::addLinkerOptionLibraries(ld::Internal& state, ld::File::AtomHan
     			}
     		}
     		catch (const char* msg) {
-				if ( strstr(msg, "but linking") != nullptr )
-					warning("%s '%s'", msg, "<libname>");
-    			// <rdar://problem/40829444> only warn about missing auto-linked library if some missing symbol error happens later
-    			state.missingLinkerOptionLibraries.insert(std::get<2>(triple));
+				handleLinkerOptionException(msg, state, std::get<2>(triple));
     		}
     		state.linkerOptionLibraries.insert(std::get<2>(triple));
 		}
 	}
+}
+
+void InputFiles::handleLinkerOptionException(const char *msg, ld::Internal& state, const char *libName) {
+	if ( strstr(msg, "but linking") != nullptr )
+		warning("%s '%s'", msg, "<libname>");
+	// <rdar://problem/40829444> only warn about missing auto-linked library if some missing symbol error happens later
+	state.missingLinkerOptionLibraries.insert(libName);
 }
 
 void InputFiles::createIndirectDylibs()

--- a/ld/src/ld/InputFiles.h
+++ b/ld/src/ld/InputFiles.h
@@ -77,6 +77,7 @@ public:
 	void						archives(ld::Internal& state);
 	
 	void						addLinkerOptionLibraries(ld::Internal& state, ld::File::AtomHandler& handler);
+	void handleLinkerOptionException(const char *msg, ld::Internal& state, const char *libName);
 	void						createIndirectDylibs();
 
 	// for -print_statistics


### PR DESCRIPTION
In stock ld, it goes roughly
```
for (library : libraries) {
  try {
    library.libraryStuffPart1();
    library.libraryStuffPart2();
    library.libraryStuffPart3();
  } catch (...) {...}
}
```

however, zld is parallelized as such:
```
for (library : libraries) {
    library.libraryStuffPart1();
    queueItems.enqueueLibraryStuffPart2(library);
}
parallel for (queueItem : queueItems) {
  queueItem.run();
}
for (library : libraries) {
  try {
    library.libraryStuffPart3();
   } catch (...) {...}
}
```

so, we're missing try-catches for the first and second blocks. for the second one though, we'd have to use locking to avoid a race condition in the catch handler, and the errors there appear to be unrelated to the catch statement (which seems to be specifically for if it can't find the library). so, this fix just adds the catch statement to the first block