### PR TITLE
Fix tapi simulator warnings

### DIFF
--- a/ld/src/ld/PlatformSupport.cpp
+++ b/ld/src/ld/PlatformSupport.cpp
@@ -176,6 +176,13 @@ void VersionSet::checkDylibCrosslink(const VersionSet& dylibPlatforms, const std
                         if ( (getenv("RC_XBS") != NULL) && (getenv("RC_BUILDIT") == NULL) )
                             break;
                     case PlatEnforce::warning: {
+                        // zld: if the .tbd supports macOS, and cmdLinePlatform is some simulator platform, then
+                        // allow it to occur. Otherwise, it seems with tapi v4 files in Xcode 12, there are .tbd files
+                        // in that folder without the right simulators included in their platform list
+                        bool isSimulator = cmdLinePlatform == Platform::iOS_simulator || cmdLinePlatform == Platform::tvOS_simulator || cmdLinePlatform == Platform::watchOS_simulator;
+                        if (isSimulator && dylibPlatforms.contains(Platform::macOS)) {
+                            break;
+                        }
                         if ( !warned ) {
                             warning("building for %s, but linking in %s file (%s) built for %s",
                                     to_str().c_str(),  dylibType.c_str(), targetPath.c_str(), dylibPlatforms.to_str().c_str());

--- a/ld/src/ld/PlatformSupport.cpp
+++ b/ld/src/ld/PlatformSupport.cpp
@@ -177,10 +177,18 @@ void VersionSet::checkDylibCrosslink(const VersionSet& dylibPlatforms, const std
                             break;
                     case PlatEnforce::warning: {
                         // zld: if the .tbd supports macOS, and cmdLinePlatform is some simulator platform, then
-                        // allow it to occur. Otherwise, it seems with tapi v4 files in Xcode 12, there are .tbd files
+                        // allow it to occur. Otherwise, it seems with tapi v4 files in Xcode 12, there are system .tbd files
                         // in that folder without the right simulators included in their platform list
                         bool isSimulator = cmdLinePlatform == Platform::iOS_simulator || cmdLinePlatform == Platform::tvOS_simulator || cmdLinePlatform == Platform::watchOS_simulator;
-                        if (isSimulator && dylibPlatforms.contains(Platform::macOS)) {
+                        auto slashPos = targetPath.rfind("/");
+                        bool isSystem = false;
+                        if (slashPos != std::string::npos) {
+                            auto basename = targetPath.substr(slashPos + 1);
+                            if (basename.find("libsystem_") == 0 || targetPath.rfind("/host/") == slashPos - 5) {
+                                isSystem = true;
+                            }
+                        }
+                        if (isSimulator && isSystem && dylibPlatforms.contains(Platform::macOS)) {
                             break;
                         }
                         if ( !warned ) {


### PR DESCRIPTION
E.g. for `/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk/usr/lib/systemlibsystem_pthread.tbd` we see:
```
targets:         [ i386-macos, x86_64-macos, x86_64-maccatalyst, arm64-macos, arm64-maccatalyst ]
```
with no mention of the simulator, even though it's in the simulator's sdk dir. So for now, just treat it as being ok. It seems like these .tbd files are specifically system ones, and that may be to interact properly with the host, macOS