### PR TITLE
Add a note about rules_apple_linker

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ build --linkopt=-Wl,-zld_original_ld_path,__BAZEL_XCODE_DEVELOPER_DIR__/Toolchai
 
 Note that you will need to disable sandbox for this to work now. Additionally, to make the linking actions cacheable, the path to zld must be deterministic (e.g. `/tmp/zld-09ea158`, where `09ea158` is zld version).
 
-Another option to use `zld` in bazel is via [rules_apple_linker](https://github.com/keith/rules_apple_linker).
+Another option to use `zld` in Bazel is via [rules_apple_linker](https://github.com/keith/rules_apple_linker).
 
 #### If using Rust:
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ build --linkopt=-Wl,-zld_original_ld_path,__BAZEL_XCODE_DEVELOPER_DIR__/Toolchai
 
 Note that you will need to disable sandbox for this to work now. Additionally, to make the linking actions cacheable, the path to zld must be deterministic (e.g. `/tmp/zld-09ea158`, where `09ea158` is zld version).
 
+Another option to use `zld` in bazel is via [rules_apple_linker](https://github.com/keith/rules_apple_linker).
+
 #### If using Rust:
 
 You can edit `~/.cargo/config` to add a linker flag, e.g.:


### PR DESCRIPTION
I think it'd be nice to point to this ruleset in the readme which provides a slightly simpler integration point for bazel users.